### PR TITLE
Handle all the YAML scalar types

### DIFF
--- a/tests/yaml-types/a.yaml
+++ b/tests/yaml-types/a.yaml
@@ -1,0 +1,6 @@
+null: null
+bool: true
+str: hello
+int: 42
+float: 0.5
+timestamp: 2022-02-05T10:30:00.1Z

--- a/tests/yaml-types/cmd
+++ b/tests/yaml-types/cmd
@@ -1,0 +1,1 @@
+bkl a.yaml

--- a/tests/yaml-types/expected
+++ b/tests/yaml-types/expected
@@ -1,0 +1,5 @@
+bool: true
+float: 0.5
+int: 42
+str: hello
+timestamp: "2022-02-05T10:30:00.1Z"

--- a/yaml.go
+++ b/yaml.go
@@ -113,10 +113,18 @@ func yamlTranslateNode(node *yaml.Node) (any, error) {
 
 			return strconv.ParseInt(node.Value, 10, 64)
 
+		case "!!float":
+			v, err := strconv.ParseFloat(node.Value, 32)
+			if err == nil {
+				return v, nil
+			}
+
+			return strconv.ParseFloat(node.Value, 64)
+
 		case "!!null":
 			return nil, nil
 
-		case "!!str":
+		case "!!str", "!!timestamp":
 			return node.Value, nil
 
 		default:


### PR DESCRIPTION
- Floats are actually used in Kubernetes configs.
- I don't know of anyone using Timestamps, but we might as well not crash if we get one. We'll just interpret it as a string.