### PR TITLE
Handle yaml merges

### DIFF
--- a/tests/yaml-merge-multiple/a.b.yaml
+++ b/tests/yaml-merge-multiple/a.b.yaml
@@ -1,0 +1,3 @@
+- $match:
+    name: copy
+  isCopy: true

--- a/tests/yaml-merge-multiple/a.yaml
+++ b/tests/yaml-merge-multiple/a.yaml
@@ -1,0 +1,11 @@
+- &anchor
+  bar: 2
+  foo: 1
+  name: original
+- &otherAnchor
+  baz: 3
+  foo: 4
+- name: copy
+  <<:
+    - *otherAnchor
+    - *anchor

--- a/tests/yaml-merge-multiple/cmd
+++ b/tests/yaml-merge-multiple/cmd
@@ -1,0 +1,1 @@
+bkl a.b.yaml

--- a/tests/yaml-merge-multiple/expected
+++ b/tests/yaml-merge-multiple/expected
@@ -1,0 +1,10 @@
+- bar: 2
+  foo: 1
+  name: original
+- baz: 3
+  foo: 4
+- bar: 2
+  baz: 3
+  foo: 4
+  isCopy: true
+  name: copy

--- a/tests/yaml-merge/a.b.yaml
+++ b/tests/yaml-merge/a.b.yaml
@@ -1,0 +1,3 @@
+- $match:
+    name: copy
+  isCopy: true

--- a/tests/yaml-merge/a.yaml
+++ b/tests/yaml-merge/a.yaml
@@ -1,0 +1,6 @@
+- &anchor
+  bar: 2
+  foo: 1
+  name: original
+- name: copy
+  <<: *anchor

--- a/tests/yaml-merge/cmd
+++ b/tests/yaml-merge/cmd
@@ -1,0 +1,1 @@
+bkl a.b.yaml

--- a/tests/yaml-merge/expected
+++ b/tests/yaml-merge/expected
@@ -1,0 +1,7 @@
+- bar: 2
+  foo: 1
+  name: original
+- bar: 2
+  foo: 1
+  isCopy: true
+  name: copy

--- a/yaml.go
+++ b/yaml.go
@@ -97,7 +97,7 @@ func yamlTranslateNode(node *yaml.Node) (any, error) {
 					return nil, err
 				}
 
-				err = yamlMerge(&ret, v2, node.Content[i+1])
+				err = yamlMerge(ret, v2, node.Content[i+1])
 				if err != nil {
 					return nil, err
 				}
@@ -164,18 +164,18 @@ func yamlTranslateNode(node *yaml.Node) (any, error) {
 }
 
 // Merge mapping or list of mappings into a destination mapping, as per https://yaml.org/type/merge.html
-func yamlMerge(dst *map[string]any, src any, node *yaml.Node) error {
+func yamlMerge(dst map[string]any, src any, node *yaml.Node) error {
 	switch src2 := src.(type) {
 	case map[string]any:
 		for k, v := range src2 {
-			(*dst)[k] = v
+			dst[k] = v
 		}
 	case []any:
 		for i := len(src2) - 1; i >= 0; i-- {
 			switch inner := src2[i].(type) {
 			case map[string]any:
 				for k, v := range inner {
-					(*dst)[k] = v
+					dst[k] = v
 				}
 			default:
 				return fmt.Errorf("unknown type for merge target: %d (%w)", node.Kind, ErrInvalidType)

--- a/yaml.go
+++ b/yaml.go
@@ -89,7 +89,7 @@ func yamlTranslateNode(node *yaml.Node) (any, error) {
 	case yaml.MappingNode:
 		ret := map[string]any{}
 
-		mergedIndices := map[int]bool{}
+		// First see if there's a merge statement, and merge the referenced map(s) into ret.
 		for i := 0; i+1 < len(node.Content); i += 2 {
 			if node.Content[i].Value == "<<" {
 				v2, err := yamlTranslateNode(node.Content[i+1])
@@ -101,13 +101,12 @@ func yamlTranslateNode(node *yaml.Node) (any, error) {
 				if err != nil {
 					return nil, err
 				}
-
-				mergedIndices[i] = true
 			}
 		}
 
+		// Next iterate over all the local values of the map.
 		for i := 0; i+1 < len(node.Content); i += 2 {
-			if mergedIndices[i] {
+			if node.Content[i].Value == "<<" {
 				continue
 			}
 


### PR DESCRIPTION
These worked in version 1.0.42 because the yamlv3 implementation did them for us.